### PR TITLE
Add Spanish translation toggle

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -22,6 +22,8 @@
         >Cristóbal Jurado ⚡️</a
       >
     </div>
-    <div class="navbar-end"></div>
+    <div class="navbar-end">
+      <button id="lang-toggle" class="btn btn-sm btn-outline">ES</button>
+    </div>
   </div>
 </div>

--- a/src/components/SideBarMenu.astro
+++ b/src/components/SideBarMenu.astro
@@ -4,15 +4,15 @@ const activeClass = "bg-base-300"; // For primary color replace with `active` cl
 ---
 
 <ul class="menu grow shrink menu-md overflow-y-auto">
-  <li><a class="py-3 text-base" id="home" href="/">Home</a></li>
-  <li><a class="py-3 text-base" id="projects" href="/projects">Projects</a></li>
-  <li><a class="py-3 text-base" id="cv" href="/cv">CV</a></li>
+  <li><a class="py-3 text-base" id="home" href="/" data-i18n-link="home">Home</a></li>
+  <li><a class="py-3 text-base" id="projects" href="/projects" data-i18n-link="projects-link">Projects</a></li>
+  <li><a class="py-3 text-base" id="cv" href="/cv" data-i18n-link="cv">CV</a></li>
   <li>
     <a
       class="py-3 text-base"
       href="mailto:c.jurado.oller@gmail.com"
       target="_blank"
-      referrerpolicy="no-referrer-when-downgrade">Contact</a
+      referrerpolicy="no-referrer-when-downgrade" data-i18n-link="contact">Contact</a
     >
   </li>
 </ul>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,5 +43,52 @@ const {
       </div>
       {includeSidebar && <SideBar sideBarActiveItemID={sideBarActiveItemID} />}
     </div>
+    <script>
+      const translations = {
+        en: {
+          home: 'Home',
+          'projects-link': 'Projects',
+          cv: 'CV',
+          contact: 'Contact',
+          welcome: 'Hey there \uD83D\uDC4B',
+          'im-name': "I'm Crist\u00F3bal Jurado",
+          title: 'Software Engineer',
+          connect: "Let's connect!",
+          projects: 'My last projects </>'
+        },
+        es: {
+          home: 'Inicio',
+          'projects-link': 'Proyectos',
+          cv: 'CV',
+          contact: 'Contacto',
+          welcome: 'Hola \uD83D\uDC4B',
+          'im-name': 'Soy Crist\u00F3bal Jurado',
+          title: 'Ingeniero de Software',
+          connect: '\u00A1Conectemos!',
+          projects: 'Mis \u00FAltimos proyectos </>'
+        }
+      };
+      let currentLang = document.documentElement.lang || 'en';
+      const toggleBtn = document.getElementById('lang-toggle');
+      function applyTranslations(lang) {
+        const dict = translations[lang];
+        if (!dict) return;
+        if (toggleBtn) toggleBtn.innerText = lang.toUpperCase();
+        for (const [key, value] of Object.entries(dict)) {
+          const elem = document.querySelector(`[data-i18n="${key}"]`);
+          elem && (elem.innerHTML = value);
+          document
+            .querySelectorAll(`[data-i18n-link="${key}"]`)
+            .forEach((el) => (el.innerText = value));
+        }
+      }
+      function toggleLanguage() {
+        currentLang = currentLang === 'en' ? 'es' : 'en';
+        document.documentElement.lang = currentLang;
+        applyTranslations(currentLang);
+      }
+      toggleBtn && toggleBtn.addEventListener('click', toggleLanguage);
+      applyTranslations(currentLang);
+    </script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,9 +5,9 @@ import HorizontalCard from "../components/HorizontalCard.astro";
 
 <BaseLayout sideBarActiveItemID="home">
   <div class="pb-12 mt-5">
-    <div class="text-xl py-1">Hey there 👋</div>
-    <div class="text-5xl font-bold">I'm Cristóbal Jurado</div>
-    <div class="text-3xl py-3 font-bold">Software Engineer</div>
+    <div class="text-xl py-1" data-i18n="welcome">Hey there 👋</div>
+    <div class="text-5xl font-bold" data-i18n="im-name">I'm Cristóbal Jurado</div>
+    <div class="text-3xl py-3 font-bold" data-i18n="title">Software Engineer</div>
     <div class="py-2">
       <text class="text-lg">
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Nobis
@@ -21,14 +21,14 @@ import HorizontalCard from "../components/HorizontalCard.astro";
         href="https://twitter.com/CjuradoDev"
         target="_blank"
         class="btn btn-outline ml-5"
+        data-i18n="connect"
       >
-        Let's connect!</a
-      >
+        Let's connect!</a>
     </div>
   </div>
 
   <div>
-    <div class="text-3xl w-full font-bold mb-2">My last projects {"</>"}</div>
+    <div class="text-3xl w-full font-bold mb-2" data-i18n="projects">My last projects {"</>"}</div>
   </div>
 
   <HorizontalCard


### PR DESCRIPTION
## Summary
- add language switcher to header
- mark sidebar and home page text for translation
- load translations and toggle them in BaseLayout

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869adc7521c832fb1985c774cea9294