### PR TITLE
Add language toggle button

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,7 +23,7 @@
       >
     </div>
     <div class="navbar-end">
-      <button id="lang-toggle" class="btn btn-sm btn-outline">ES</button>
+      <button class="btn btn-sm btn-outline lang-toggle">ES</button>
     </div>
   </div>
 </div>

--- a/src/components/SideBar.astro
+++ b/src/components/SideBar.astro
@@ -17,7 +17,10 @@ const { sideBarActiveItemID } = Astro.props;
         </div>
       </a>
     </div>
-    <SideBarMenu sideBarActiveItemID={sideBarActiveItemID} />
-    <SideBarFooter />
-  </aside>
+      <SideBarMenu sideBarActiveItemID={sideBarActiveItemID} />
+      <div class="hidden lg:flex justify-center mb-4">
+        <button class="btn btn-sm btn-outline lang-toggle">ES</button>
+      </div>
+      <SideBarFooter />
+    </aside>
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -69,11 +69,11 @@ const {
         }
       };
       let currentLang = document.documentElement.lang || 'en';
-      const toggleBtn = document.getElementById('lang-toggle');
+      const toggleBtns = document.querySelectorAll('.lang-toggle');
       function applyTranslations(lang) {
         const dict = translations[lang];
         if (!dict) return;
-        if (toggleBtn) toggleBtn.innerText = lang.toUpperCase();
+        toggleBtns.forEach((btn) => (btn.innerText = lang.toUpperCase()));
         for (const [key, value] of Object.entries(dict)) {
           const elem = document.querySelector(`[data-i18n="${key}"]`);
           elem && (elem.innerHTML = value);
@@ -87,7 +87,9 @@ const {
         document.documentElement.lang = currentLang;
         applyTranslations(currentLang);
       }
-      toggleBtn && toggleBtn.addEventListener('click', toggleLanguage);
+      toggleBtns.forEach((btn) =>
+        btn.addEventListener('click', toggleLanguage)
+      );
       applyTranslations(currentLang);
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add a language toggle button in the mobile header and sidebar
- support multiple toggle buttons with a script update

## Testing
- `npm run build` *(fails: astro not found)*
- `npm install` *(fails to download packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6869b00d89fc832f92a68c59d7477dc2